### PR TITLE
Update dependencies - notably kiddo from 2.1 to 3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,18 @@ test-log           = { version = "0.2", default-features = false, features = ["t
 serde      = { version = "1", features = ["derive"] }
 serde_json = "1"
 config     = "0.13"
-csv        = "1.2"
-rayon      = "1.7"
+csv        = "1"
+rayon      = "1"
 strsim     = "0.10"
-kiddo      = "2.1"
+kiddo      = "3.0"
 geoip2     = { version = "0.1.6" }
 
 bincode   = "1.3.3"
-itertools = "0.11"
+itertools = "0.12"
 
 # service
 oaph       = { version = "0.1" }
-ntex       = { version = "0.7.3", features = ["tokio"] }
+ntex       = { version = "0.7", features = ["tokio"] }
 ntex-files = "0.3"
 ntex-cors  = "0.4"
 

--- a/geosuggest-core/src/lib.rs
+++ b/geosuggest-core/src/lib.rs
@@ -9,7 +9,8 @@ use itertools::Itertools;
 
 use kiddo::{
     self,
-    float::{distance::squared_euclidean, kdtree::KdTree},
+    float::kdtree::KdTree,
+    SquaredEuclidean,
 };
 
 use rayon::prelude::*;
@@ -420,7 +421,7 @@ impl Engine {
 
         let items = &mut self
             .tree
-            .nearest_n(&[loc.0, loc.1], nearest_limit, &squared_euclidean);
+            .nearest_n::<SquaredEuclidean>(&[loc.0, loc.1], nearest_limit);
 
         let items: &mut dyn Iterator<Item = (_, &CitiesRecord)> = if let Some(countries) = countries
         {


### PR DESCRIPTION
Hi @estin ,

Just updated dependencies.

The [ImmutableKdTree](https://docs.rs/kiddo/3.0.0/kiddo/immutable/float/kdtree/struct.ImmutableKdTree.html) seems particularly well-suited to geosuggest.

Do you think we migrate to it?