### PR TITLE
turn on kiddo immutable feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 authors = ["geosuggest contributors"]
 license = "MIT"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ config     = "0.13"
 csv        = "1"
 rayon      = "1"
 strsim     = "0.10"
-kiddo      = "4.0"
+kiddo      = { version = "4.0", features = ["immutable"] }
 geoip2     = "0.1.6"
 
 bincode   = "1.3.3"


### PR DESCRIPTION
to ensure that we get kiddo 4.0, not 3.0 when building, even though we're not using immutable at the moment.

In qsv, even if I use geosuggest 0.5.2, it was linking in kiddo 3.0, not kiddo 4.0. Enabling the immutable feature fixed it.
